### PR TITLE
feat: 异步加载导致页面重绘时，蒙层重绘

### DIFF
--- a/src/Guide/index.tsx
+++ b/src/Guide/index.tsx
@@ -180,6 +180,7 @@ const Guide: React.FC<IGuide> = (props) => {
           className={maskClassName}
           anchorEl={anchorEl as Element}
           realWindow={realWindow as Window}
+          timestamp={new Date().getTime()}
         />
       )}
       <Modal

--- a/src/Mask/index.tsx
+++ b/src/Mask/index.tsx
@@ -7,12 +7,14 @@ interface IMask {
   className: string;
   anchorEl: Element;
   realWindow: Window;
+  timestamp?: number;
 }
 
 const Mask: React.FC<IMask> = ({
   className,
   anchorEl,
   realWindow,
+  timestamp,
 }): JSX.Element => {
   const [style, setStyle] = useState<Record<string, number>>({});
   const timerRef = useRef<number>(0);
@@ -28,6 +30,11 @@ const Mask: React.FC<IMask> = ({
       calculateStyle();
     });
   };
+
+  // 异步加载导致页面重绘时，蒙层重绘
+  useEffect(() => {
+    calculateStyle();
+  }, [timestamp]);
 
   useEffect(() => {
     calculateStyle();


### PR DESCRIPTION
fix: 当目标元素受到页面重绘影响时(比如接口数据加载的元素)，蒙层不会重新渲染，仍然位于初始位置。例如：
![image](https://user-images.githubusercontent.com/23523674/126289966-9fd1bf7d-9984-4920-aaff-5acd5da00cb4.png)
