### PR TITLE
fix: 解决长页面有滚动轴的情况下mask的宽度获取错误

### DIFF
--- a/src/utils/getMaskStyle.ts
+++ b/src/utils/getMaskStyle.ts
@@ -2,11 +2,12 @@ import { getDocumentElement } from './utils';
 
 export const getMaskStyle = (anchorEl: Element): Record<string, number> => {
   const scrollContainer = getDocumentElement(anchorEl);
+  // prevent scrolling
+  scrollContainer.style.overflow = 'hidden';
 
   const { scrollWidth, scrollHeight, scrollTop } = scrollContainer;
 
-  // prevent scrolling
-  scrollContainer.style.overflow = 'hidden';
+
 
   const anchorPos = anchorEl.getBoundingClientRect();
   const { height, width, left } = anchorPos;


### PR DESCRIPTION
创建mask时先设置overflow = 'hidden', 在获取宽度，否则宽度会少一截浏览器滚动轴的宽度。